### PR TITLE
Allow building at OBS and add Chum section

### DIFF
--- a/rpm/harbour-sailhub.spec
+++ b/rpm/harbour-sailhub.spec
@@ -32,6 +32,16 @@ BuildRequires:  desktop-file-utils
 %description
 SailHub is an inoffical GitHub app for Sailfish OS
 
+%if "%{?vendor}" == "chum"
+PackageName: SailHub
+Type: desktop-application
+Categories:
+  - Development
+Icon: https://raw.githubusercontent.com/black-sheep-dev/harbour-sailhub/main/icons/harbour-sailhub.svg
+Url:
+  Donation: https://www.paypal.com/paypalme/nubecula/1
+%endif
+
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/rpm/harbour-sailhub.spec
+++ b/rpm/harbour-sailhub.spec
@@ -25,6 +25,8 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
+BuildRequires:  pkgconfig(keepalive)
+BuildRequires:  qt5-qttools-linguist
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-sailhub.yaml
+++ b/rpm/harbour-sailhub.yaml
@@ -13,6 +13,17 @@ Sources:
 - '%{name}-%{version}.tar.bz2'
 Description: |
   SailHub is an inoffical GitHub app for Sailfish OS
+
+  %if "%{?vendor}" == "chum"
+  PackageName: SailHub
+  Type: desktop-application
+  Categories:
+    - Development
+  Icon: https://raw.githubusercontent.com/black-sheep-dev/harbour-sailhub/main/icons/harbour-sailhub.svg
+  Url:
+    Donation: https://www.paypal.com/paypalme/nubecula/1
+  %endif
+
 Builder: qmake5
 
 # This section specifies build dependencies that are resolved using pkgconfig.

--- a/rpm/harbour-sailhub.yaml
+++ b/rpm/harbour-sailhub.yaml
@@ -24,10 +24,11 @@ PkgConfigBR:
   - Qt5Quick
   - Qt5DBus
   - nemonotifications-qt5
+  - keepalive
 
 # Build dependencies without a pkgconfig setup can be listed here
-# PkgBR:
-#   - package-needed-to-build
+PkgBR:
+  - qt5-qttools-linguist
 
 # Runtime dependencies which are not automatically detected
 Requires:


### PR DESCRIPTION
This will allow to build SailHub at OBS and add it to Chum repositories. As you could see, couple of dependencies were missing (preinstalled in SDK and that's why you didn't notice) and I have added Chum metadata section. It is possible to add screenshots as well, but those would require screenshots at your repository. For donations, only one link is supported and I have added your PayPal link. This can be adjusted as well.