### PR TITLE
Fix changelog date

### DIFF
--- a/rpm/harbour-sailhub.changes
+++ b/rpm/harbour-sailhub.changes
@@ -1,4 +1,4 @@
-* Wed Jan 05 2021 Black Sheep <blacksheep@nubecula.org> 0.1.2-1
+* Wed Jan 05 2022 Black Sheep <blacksheep@nubecula.org> 0.1.2-1
 - Removed own implemation for storing secret token (it didn't work reliable, sorry for that :´-)). You need to enter it again.
 - Add link handler to the system. You can open links to github.com inside the app
 - Translation updates


### PR DESCRIPTION
Turned out that older SFOS versions were more picky about chaangelog date mixup. With this fix, all will build as it should, see https://build.sailfishos.org/package/show/sailfishos:chum:testing/harbour-sailhub (currently from my fork). 

To release in Chum proper, would be great to get this merged. If you don't mind, please tag the merge commit as well. OBS automatically overwrites version based on commit tag. If missing, it will use latest applicable and then add branch-datetime-commit based extension. Which is not very pretty :)