### PR TITLE
Fix: move from token to Bearer in Authentication header

### DIFF
--- a/src/api/graphqlconnector.cpp
+++ b/src/api/graphqlconnector.cpp
@@ -35,7 +35,7 @@ void GraphQLConnector::sendQuery(const GraphQLQuery &query, quint8 requestType, 
     request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept-Encoding", "gzip");
-    request.setRawHeader("Authorization", "token " + m_token.toUtf8());
+    request.setRawHeader("Authorization", "Bearer " + m_token.toUtf8());
     request.setRawHeader("GraphQL-Features", "discussions_api");
 
     // send request

--- a/src/api/restapiconnector.cpp
+++ b/src/api/restapiconnector.cpp
@@ -96,7 +96,7 @@ QNetworkRequest RestApiConnector::getRequest(const QString &endpoint)
     request.setRawHeader("Accept", "application/vnd.github.v3+json");
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept-Encoding", "gzip");
-    request.setRawHeader("Authorization", "token " + m_token.toUtf8());
+    request.setRawHeader("Authorization", "Bearer " + m_token.toUtf8());
 
     return request;
 }

--- a/translations/harbour-sailhub-fr.ts
+++ b/translations/harbour-sailhub-fr.ts
@@ -21,7 +21,7 @@
     </message>
     <message>
         <source>Your language is not available? You are welcome to support this project by translating it on my self hosted Weblate server.</source>
-        <translation>Votre langue n&apos;est pas disponible&#xa0;? Votre aide est la bienvenue pour traduire ce projet sur mon serveur Weblate dédié.</translation>
+        <translation>Votre langue n&apos;est pas disponible ? Votre aide est la bienvenue pour traduire ce projet sur mon serveur Weblate dédié.</translation>
     </message>
     <message>
         <source>Sources</source>
@@ -33,7 +33,7 @@
     </message>
     <message>
         <source>If you like my work why not buy me a beer?</source>
-        <translation>Si vous appréciez mon travail pourquoi ne pas m&apos;offrir une bière&#xa0;?</translation>
+        <translation>Si vous appréciez mon travail pourquoi ne pas m&apos;offrir une bière ?</translation>
     </message>
     <message>
         <source>Donate with PayPal</source>
@@ -49,7 +49,7 @@
     </message>
     <message>
         <source>All emojis designed by %1. License: %2</source>
-        <translation>Les émoticônes sont créés par %1. Licence&#xa0;: %2</translation>
+        <translation>Les émoticônes sont créés par %1. Licence : %2</translation>
     </message>
     <message>
         <source>Give star</source>
@@ -64,7 +64,7 @@
     </message>
     <message>
         <source>%1 says thank you for your star!</source>
-        <translation>%1 vous remercie pour votre étoile&#xa0;!</translation>
+        <translation>%1 vous remercie pour votre étoile !</translation>
     </message>
     <message>
         <source>Stargazer</source>
@@ -1275,8 +1275,8 @@
     <message numerus="yes">
         <source>%n year(s) ago</source>
         <translation>
-            <numerusform>il y a %n&#xa0;an</numerusform>
-            <numerusform>il y a %n&#xa0;années</numerusform>
+            <numerusform>il y a %n an</numerusform>
+            <numerusform>il y a %n années</numerusform>
         </translation>
     </message>
 </context>
@@ -2043,11 +2043,11 @@
     </message>
     <message>
         <source>This token can be created in developer settings on GitHub.</source>
-        <translation>Ce jeton peut être créé dans «&#xa0;Developer settings&#xa0;» sur GitHub.</translation>
+        <translation>Ce jeton peut être créé dans « Developer settings » sur GitHub.</translation>
     </message>
     <message>
         <source>For a detailed description please refer the README in project repository!</source>
-        <translation>Pour une description détaillée, référez-vous au README du dépôt du projet&#xa0;!</translation>
+        <translation>Pour une description détaillée, référez-vous au README du dépôt du projet !</translation>
     </message>
     <message>
         <source>Access Token</source>
@@ -2066,7 +2066,7 @@
     </message>
     <message>
         <source>An error occured when connecting to GitHub!</source>
-        <translation>Une erreur s&apos;est produite lors de la connexion à GitHub&#xa0;!</translation>
+        <translation>Une erreur s&apos;est produite lors de la connexion à GitHub !</translation>
     </message>
     <message>
         <source>Repo doesn&apos;t exist!</source>


### PR DESCRIPTION
Recent changes require using the keyword 'Bearer' instead of 'token'. Tested with simple tokens.